### PR TITLE
Define three-argument show methods instead of two-argument

### DIFF
--- a/src/Lasso.jl
+++ b/src/Lasso.jl
@@ -182,7 +182,7 @@ mutable struct LassoPath{S<:Union{LinearModel,GeneralizedLinearModel},T} <: Regu
         new{S,T}(m, nulldev, nullb0, λ, autoλ, Xnorm)
 end
 
-function Base.show(io::IO, path::RegularizationPath)
+function Base.show(io::IO, ::MIME"text/plain", path::RegularizationPath)
     prefix = isa(path.m, GeneralizedLinearModel) ? string(typeof(distfun(path)).name.name, " ") : ""
     pathsize = size(path)
     println(io, "$(prefix)$(typeof(path).name.name) ($(pathsize[2])) solutions for $(pathsize[1]) predictors in $(path.niter) iterations):")
@@ -194,7 +194,7 @@ function Base.show(io::IO, path::RegularizationPath)
             ncoefs[i] = coefs.colptr[i+1] - coefs.colptr[i]
         end
         ncoefs[end] = nnz(coefs) - coefs.colptr[size(coefs, 2)] + 1
-        show(io, CoefTable(Union{Vector{Int},Vector{Float64}}[path.λ, path.pct_dev, ncoefs], ["λ", "pct_dev", "ncoefs"], []))
+        show(io, MIME("text/plain"), CoefTable(Union{Vector{Int},Vector{Float64}}[path.λ, path.pct_dev, ncoefs], ["λ", "pct_dev", "ncoefs"], []))
     else
         print(io, "    (not fit)")
     end

--- a/src/segselect.jl
+++ b/src/segselect.jl
@@ -325,7 +325,7 @@ function coeftable(mm::RegularizedModel)
                 ["x$i" for i = 1:size(mm.lpm.pp.X, 2)])
 end
     
-function Base.show(io::IO, obj::RegularizedModel)
+function Base.show(io::IO, ::MIME"text/plain", obj::RegularizedModel)
     # prefix = isa(obj.m, GeneralizedLinearModel) ? string(typeof(distfun(path)).name.name, " ") : ""
     println(io, "$(typeof(obj).name.name) using $(obj.select) segment of the regularization path.")
     println(io, "\nCoefficients:")
@@ -334,7 +334,7 @@ function Base.show(io::IO, obj::RegularizedModel)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", obj::StatsModels.TableRegressionModel{<:RegularizedModel})
-    show(io, obj.model)
+    show(io, MIME("text/plain"), obj.model)
 end
 
 StatsBase.vcov(obj::RegularizedModel, args...) = error("variance-covariance matrix for a regularized model is not yet implemented")

--- a/test/segselect.jl
+++ b/test/segselect.jl
@@ -6,7 +6,7 @@ using GLM: predict
 macro test_show(expr, expected)
     s = quote
         local o = IOBuffer()
-        show(o, $expr)
+        show(o, MIME("text/plain"), $expr)
         String(take!(o))
     end
     substr = quote $expected end


### PR DESCRIPTION
Replace two-argument Base.show(io::IO, obj) with the three-argument Base.show(io::IO, ::MIME"text/plain", obj) for multiline display of RegularizationPath and RegularizedModel types, as recommended by Julia community standards. Also update internal show calls and tests to use the explicit MIME type.

Fixes #92